### PR TITLE
Make main files directly executable, add option to drop to pdb terminal on exception

### DIFF
--- a/robotarena/create_web_replay.py
+++ b/robotarena/create_web_replay.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import pickle

--- a/robotarena/roborally.py
+++ b/robotarena/roborally.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import importlib.util

--- a/robotarena/roborally/config.py
+++ b/robotarena/roborally/config.py
@@ -11,6 +11,8 @@ interactive = False
 print_results = False
 # When debug_robots is set to True, a robot's move function that throws an exception will stop the simulation and print
 # the exception to the screen. This is useful for debugging.
+# When debug_robots is set to 'interactive' (with the quotes), an exception will pause the simulation and drob you to
+# a pdb (python debugger) terminal. Ctrl-d to exit, and the exception will then be printed.
 # When debug_robots is set to False, a robot that throws an exception will be dealt 1 damage, and will not stop the
 # simulation. The official match will have debug_robots set to False.
 debug_robots = False

--- a/robotarena/roborally/manager.py
+++ b/robotarena/roborally/manager.py
@@ -88,6 +88,9 @@ def record_moves_for_robots(state, debug_robots, interactive):
         robot['move'] = robot['brain'].ai.move()
       except Exception as error:
         if debug_robots:
+          if debug_robots == 'interactive':
+            import pdb
+            pdb.set_trace()
           raise error
         robot[LIFE] -= 1
         if robot[LIFE] == 0:


### PR DESCRIPTION
A super simple edit. The "shebang" lines and mode change allow you to execute the .py files directly without first calling 'python3'. The pdb addition gives you the option of dropping to a pdb terminal for more advanced debugging of your script.